### PR TITLE
fix: prevent setting bar too left and getting off the left edge

### DIFF
--- a/scripts/jquery.popline.js
+++ b/scripts/jquery.popline.js
@@ -26,6 +26,7 @@
         var left = null, top = null;
         var rect = window.getSelection().getRangeAt(0).getBoundingClientRect();
         left = event.pageX - bar.width() / 2;
+        if (left < 0) left = 10;
         top = event.pageY - bar.outerHeight() - parseInt(target.css('font-size')) / 2;
         $.popline.current.show({left: left, top: top});
       }


### PR DESCRIPTION
When the most left side of the text is selected, the bar is positioned too left and is getting off the left edge of the browser, see screenshot.

![screen shot 2013-07-15 at 22 20 52](https://f.cloud.github.com/assets/442278/798148/fd279050-ed5a-11e2-823a-e333e3d1d8d2.png)
